### PR TITLE
Fix to download a rood directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { IDisposable } from '@lumino/disposable';
 import { Menu } from '@lumino/widgets';
 import { archiveIcon, unarchiveIcon } from './icon';
 
-const DIRECTORIES_URL = 'directories';
+const DIRECTORIES_URL = 'directories/';
 const EXTRACT_ARCHIVE_URL = 'extract-archive';
 type ArchiveFormat =
   | null


### PR DESCRIPTION
It seems that both versions v3.x and v2.x fail to download root directory.
When path is `/`, the result of `URLExt.encodeParts(path)` will become an empty string.
So the `url` will become like this `http://localhost:8888/directories?archiveToken=...`.
Server extension of `jupyter-archive` will fail to  route this URL, won’t it?

![スクリーンショット 2021-04-16 15 36 29](https://user-images.githubusercontent.com/4404574/114981824-8c09ce00-9ec9-11eb-92e1-a34ab4f3c670.png)

In my local environment, this problem was reproduced even with a clean jupyter lab (v3.0.14).
Could you confirm this problem and this PR? Thank you!