### PR TITLE
Check the extension of extracted file for backward matching

### DIFF
--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -74,13 +74,13 @@ def make_reader(archive_path):
 
     archive_format = "".join(archive_path.suffixes)[1:]
 
-    if archive_format == "zip":
+    if archive_format.endswith("zip"):
         archive_file = zipfile.ZipFile(archive_path, mode="r")
-    elif archive_format in ["tgz", "tar.gz"]:
+    elif any([archive_format.endswith(ext) for ext in ["tgz", "tar.gz"]]):
         archive_file = tarfile.open(archive_path, mode="r|gz")
-    elif archive_format in ["tbz", "tbz2", "tar.bz", "tar.bz2"]:
+    elif any([archive_format.endswith(ext) for ext in ["tbz", "tbz2", "tar.bz", "tar.bz2"]]):
         archive_file = tarfile.open(archive_path, mode="r|bz2")
-    elif archive_format in ["txz", "tar.xz"]:
+    elif any([archive_format.endswith(ext) for ext in ["txz", "tar.xz"]]):
         archive_file = tarfile.open(archive_path, mode="r|xz")
     else:
         raise ValueError("'{}' is not a valid archive format.".format(archive_format))

--- a/jupyter_archive/tests/test_archive_handler.py
+++ b/jupyter_archive/tests/test_archive_handler.py
@@ -102,7 +102,7 @@ async def test_download(jp_fetch, jp_root_dir, followSymlinks, download_hidden, 
     assert r.code == 200
     assert r.headers["content-type"] == "application/octet-stream"
     assert r.headers["cache-control"] == "no-cache"
-    
+
     if format == "zip":
         with zipfile.ZipFile(r.buffer, mode=mode) as zf:
             assert set(zf.namelist()) == file_list
@@ -111,6 +111,14 @@ async def test_download(jp_fetch, jp_root_dir, followSymlinks, download_hidden, 
             assert set(map(lambda m: m.name, tf.getmembers())) == file_list
 
 
+@pytest.mark.parametrize(
+    "file_name",
+    [
+        ('archive'),
+        ('archive.hello'),
+        ('archive.tar.gz'),
+    ],
+)
 @pytest.mark.parametrize(
     "format, mode",
     [
@@ -125,9 +133,9 @@ async def test_download(jp_fetch, jp_root_dir, followSymlinks, download_hidden, 
         ("tar.xz", "w|xz"),
     ],
 )
-async def test_extract(jp_fetch, jp_root_dir, format, mode):
+async def test_extract(jp_fetch, jp_root_dir, file_name, format, mode):
     # Create a dummy directory.
-    archive_dir_path = jp_root_dir / "extract-archive-dir"
+    archive_dir_path = jp_root_dir / file_name
     archive_dir_path.mkdir(parents=True)
 
     (archive_dir_path / "extract-test1.txt").write_text("hello1")
@@ -135,7 +143,7 @@ async def test_extract(jp_fetch, jp_root_dir, format, mode):
     (archive_dir_path / "extract-test3.md").write_text("hello3")
 
     # Make an archive
-    archive_dir_path = jp_root_dir / "extract-archive-dir"
+    archive_dir_path = jp_root_dir / file_name
     archive_path = archive_dir_path.with_suffix("." + format)
     if format == "zip":
         with zipfile.ZipFile(archive_path, mode=mode) as writer:


### PR DESCRIPTION
Fix #63 

I have modified it to check the extension of extracted file for backward matching.