### PR TITLE
Fix suffix check for archive extraction

### DIFF
--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -141,8 +141,7 @@ class DownloadArchiveHandler(JupyterHandler):
             raise web.HTTPError(400)
 
         archive_path = pathlib.Path(cm.root_dir) / url2path(archive_path)
-        archive_name = archive_path.name
-        archive_filename = archive_path.with_suffix(".{}".format(archive_format)).name
+        archive_filename = f"{archive_path.name}.{archive_format}"
 
         self.log.info("Prepare {} for archiving and downloading.".format(archive_filename))
         self.set_header("content-type", "application/octet-stream")

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -72,15 +72,15 @@ def make_writer(handler, archive_format="zip"):
 
 def make_reader(archive_path):
 
-    archive_format = "".join(archive_path.suffixes)[1:]
+    archive_format = "".join(archive_path.suffixes)
 
-    if archive_format.endswith("zip"):
+    if archive_format.endswith(".zip"):
         archive_file = zipfile.ZipFile(archive_path, mode="r")
-    elif any([archive_format.endswith(ext) for ext in ["tgz", "tar.gz"]]):
+    elif any([archive_format.endswith(ext) for ext in [".tgz", ".tar.gz"]]):
         archive_file = tarfile.open(archive_path, mode="r|gz")
-    elif any([archive_format.endswith(ext) for ext in ["tbz", "tbz2", "tar.bz", "tar.bz2"]]):
+    elif any([archive_format.endswith(ext) for ext in [".tbz", ".tbz2", ".tar.bz", ".tar.bz2"]]):
         archive_file = tarfile.open(archive_path, mode="r|bz2")
-    elif any([archive_format.endswith(ext) for ext in ["txz", "tar.xz"]]):
+    elif any([archive_format.endswith(ext) for ext in [".txz", ".tar.xz"]]):
         archive_file = tarfile.open(archive_path, mode="r|xz")
     else:
         raise ValueError("'{}' is not a valid archive format.".format(archive_format))

--- a/jupyter_archive/tests/test_archive_handler.py
+++ b/jupyter_archive/tests/test_archive_handler.py
@@ -144,7 +144,7 @@ async def test_extract(jp_fetch, jp_root_dir, file_name, format, mode):
 
     # Make an archive
     archive_dir_path = jp_root_dir / file_name
-    archive_path = archive_dir_path.with_suffix("." + format)
+    archive_path = archive_dir_path.with_suffix(f"{archive_dir_path.suffix}.{format}")
     if format == "zip":
         with zipfile.ZipFile(archive_path, mode=mode) as writer:
             for file_path in archive_dir_path.rglob("*"):


### PR DESCRIPTION
Ref #65 
Sorry, I noticed that implementation of #65 allows invalid file name like `hoge.aazip` because we check extension by backward matching and compared extension does not include `.`.

This PR will resolve this problem.