### PR TITLE
Don't use `ensure_python`

### DIFF
--- a/jupyter_archive/_version.py
+++ b/jupyter_archive/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Project Jupyter.
 # Distributed under the terms of the Modified BSD License.
 
-__version__ = '2.2.0'
+__version__ = '2.3.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hadim/jupyter-archive",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "description": "A Jupyterlab extension to make, download and extract archive files.",
   "keywords": [
     "jupyter",

--- a/setup.py
+++ b/setup.py
@@ -8,16 +8,12 @@ from setupbase import (
     ensure_targets,
     find_packages,
     combine_commands,
-    ensure_python,
     get_version,
     HERE,
 )
 
 # The name of the project
 name = "jupyter_archive"
-
-# Ensure a valid python version
-ensure_python(">=3.5")
 
 # Get our version
 version = get_version(pjoin(name, "_version.py"))


### PR DESCRIPTION
Remove usage of `ensure_python` (does not work with Python 3.10)