### PR TITLE
Switch from JLab to Jupyter server Python dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyterlab>=3.0.0rc13,==3.*",
+        "jupyter_server>=1.6,<2",
     ],
     extra_requires={"test": ["pytest", "pytest-tornasync"]},
     zip_safe=False,
@@ -78,6 +78,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Framework :: Jupyter",
         "Framework :: Jupyter :: JupyterLab",
         "Framework :: Jupyter :: JupyterLab :: 3",


### PR DESCRIPTION
This will allow the extension to be installed in alternative front-end like RetroLab.
And will support notebook v7.