### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -229,6 +229,18 @@ class ExtractArchiveHandler(JupyterHandler):
         self.log.info("Begin extraction of {} to {}.".format(archive_path, archive_destination))
 
         archive_reader = make_reader(archive_path)
+
+        if isinstance(archive_reader, tarfile.TarFile):
+            # Check file path to avoid path traversal
+            # See https://nvd.nist.gov/vuln/detail/CVE-2007-4559
+            with archive_reader as archive:
+                for name in archive_reader.getnames():
+                    if not str((archive_destination / name).resolve()).startswith(str(archive_destination)):
+                        self.log.error(f"The archive file includes an unsafe file: {name}")
+                        raise web.HTTPError(400)
+            # Re-open stream
+            archive_reader = make_reader(archive_path)
+
         with archive_reader as archive:
             archive.extractall(archive_destination)
 

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -235,7 +235,7 @@ class ExtractArchiveHandler(JupyterHandler):
             # See https://nvd.nist.gov/vuln/detail/CVE-2007-4559
             with archive_reader as archive:
                 for name in archive_reader.getnames():
-                    if not str((archive_destination / name).resolve()).startswith(str(archive_destination)):
+                    if os.path.relpath(archive_destination / name, archive_destination).startswith("../"):
                         self.log.error(f"The archive file includes an unsafe file: {name}")
                         raise web.HTTPError(400)
             # Re-open stream

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -235,7 +235,7 @@ class ExtractArchiveHandler(JupyterHandler):
             # See https://nvd.nist.gov/vuln/detail/CVE-2007-4559
             with archive_reader as archive:
                 for name in archive_reader.getnames():
-                    if os.path.relpath(archive_destination / name, archive_destination).startswith("../"):
+                    if os.path.relpath(archive_destination / name, archive_destination).startswith(os.pardir):
                         self.log.error(f"The archive file includes an unsafe file: {name}")
                         raise web.HTTPError(400)
             # Re-open stream

--- a/jupyter_archive/tests/test_archive_handler.py
+++ b/jupyter_archive/tests/test_archive_handler.py
@@ -209,12 +209,19 @@ async def test_extract_failure(jp_fetch, jp_root_dir, format, mode):
     assert not archive_dir_path.exists()
 
 
-async def test_extract_path_traversal(jp_fetch, jp_root_dir):
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        ("../../../../../../../../../../tmp/test"),
+        ("../test"),
+    ],
+)
+async def test_extract_path_traversal(jp_fetch, jp_root_dir, file_path):
     unsafe_file_path = jp_root_dir / "test"
     archive_path = jp_root_dir / "test.tar.gz"
     open(unsafe_file_path, 'a').close()
     with tarfile.open(archive_path, "w:gz") as tf:
-        tf.add(unsafe_file_path, "../../../../../../../../../../tmp/test")
+        tf.add(unsafe_file_path, file_path)
 
     with pytest.raises(Exception) as e:
         await jp_fetch("extract-archive", archive_path.relative_to(jp_root_dir).as_posix(), method="GET")


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2007-4559

`extractall()` of `tarfile` has path traversal vulnerability. We need to check file path before using `extractall()` to avoid it.
~If we need to add a unit test for this, please let me know.~ I added a unit test.

## How to reproduce

1. Create tar file by below codes
2. Extract the tar file by right click menu of jupyter-archive
3. `/tmp/test` will be created (After this PR, the request of extracting will be failed as 400 bad request)

```py
import tarfile
open("test", 'a').close()
tf = tarfile.open("test.tar.gz", "w:gz")
tf.add("test", "../../../../../../../../../../tmp/test")
tf.close()
```

Unrelated to this PR, is it the intended behavior that the user is not notified of an error when an extract request fails?