### PR TITLE
Show error message dialog when failed to extract an archive file

### DIFF
--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -5,7 +5,7 @@ import time
 import zipfile
 import threading
 
-from jupyter_server.base.handlers import JupyterHandler
+from jupyter_server.base.handlers import JupyterHandler, APIHandler
 from jupyter_server.utils import url2path, url_path_join
 from tornado import ioloop, web
 from urllib.parse import quote
@@ -213,7 +213,7 @@ class DownloadArchiveHandler(JupyterHandler):
         self.flush_cb.stop()
 
 
-class ExtractArchiveHandler(JupyterHandler):
+class ExtractArchiveHandler(APIHandler):
     @web.authenticated
     async def get(self, archive_path, include_body=False):
 
@@ -244,8 +244,9 @@ class ExtractArchiveHandler(JupyterHandler):
             with archive_reader as archive:
                 for name in archive_reader.getnames():
                     if os.path.relpath(archive_destination / name, archive_destination).startswith(os.pardir):
-                        self.log.error(f"The archive file includes an unsafe file: {name}")
-                        raise web.HTTPError(400)
+                        error_message = f"The archive file includes an unsafe file path: {name}"
+                        self.log.error(error_message)
+                        raise web.HTTPError(400, reason=error_message)
             # Re-open stream
             archive_reader = make_reader(archive_path)
 

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -229,6 +229,18 @@ class ExtractArchiveHandler(JupyterHandler):
         self.log.info("Begin extraction of {} to {}.".format(archive_path, archive_destination))
 
         archive_reader = make_reader(archive_path)
+
+        if isinstance(archive_reader, tarfile.TarFile):
+            # Check file path to avoid path traversal
+            # See https://nvd.nist.gov/vuln/detail/CVE-2007-4559
+            with archive_reader as archive:
+                for name in archive_reader.getnames():
+                    if not str((archive_destination / name).resolve()).startswith(str(archive_destination)):
+                        self.log.error(f"The archive file includes an unsafe file: {name}")
+                        raise web.HTTPError(400)
+            # Re-open stream
+            archive_reader = make_reader(archive_path)
+
         with archive_reader as archive:
             archive.extractall(archive_destination)
 

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -235,7 +235,7 @@ class ExtractArchiveHandler(JupyterHandler):
             # See https://nvd.nist.gov/vuln/detail/CVE-2007-4559
             with archive_reader as archive:
                 for name in archive_reader.getnames():
-                    if not str((archive_destination / name).resolve()).startswith(str(archive_destination)):
+                    if os.path.relpath(archive_destination / name, archive_destination).startswith("../"):
                         self.log.error(f"The archive file includes an unsafe file: {name}")
                         raise web.HTTPError(400)
             # Re-open stream

--- a/jupyter_archive/handlers.py
+++ b/jupyter_archive/handlers.py
@@ -235,7 +235,7 @@ class ExtractArchiveHandler(JupyterHandler):
             # See https://nvd.nist.gov/vuln/detail/CVE-2007-4559
             with archive_reader as archive:
                 for name in archive_reader.getnames():
-                    if os.path.relpath(archive_destination / name, archive_destination).startswith("../"):
+                    if os.path.relpath(archive_destination / name, archive_destination).startswith(os.pardir):
                         self.log.error(f"The archive file includes an unsafe file: {name}")
                         raise web.HTTPError(400)
             # Re-open stream

--- a/jupyter_archive/tests/test_archive_handler.py
+++ b/jupyter_archive/tests/test_archive_handler.py
@@ -209,12 +209,19 @@ async def test_extract_failure(jp_fetch, jp_root_dir, format, mode):
     assert not archive_dir_path.exists()
 
 
-async def test_extract_path_traversal(jp_fetch, jp_root_dir):
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        ("../../../../../../../../../../tmp/test"),
+        ("../test"),
+    ],
+)
+async def test_extract_path_traversal(jp_fetch, jp_root_dir, file_path):
     unsafe_file_path = jp_root_dir / "test"
     archive_path = jp_root_dir / "test.tar.gz"
     open(unsafe_file_path, 'a').close()
     with tarfile.open(archive_path, "w:gz") as tf:
-        tf.add(unsafe_file_path, "../../../../../../../../../../tmp/test")
+        tf.add(unsafe_file_path, file_path)
 
     with pytest.raises(Exception) as e:
         await jp_fetch("extract-archive", archive_path.relative_to(jp_root_dir).as_posix(), method="GET")

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,9 @@ function extractArchiveRequest(path: string): Promise<void> {
 
   return ServerConnection.makeRequest(url, request, settings).then(response => {
     if (response.status !== 200) {
-      throw new ServerConnection.ResponseError(response);
+      const error = new ServerConnection.ResponseError(response);
+      showErrorMessage('Fail to extract the archive file', error);
+      throw error;
     }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,9 +107,10 @@ function extractArchiveRequest(path: string): Promise<void> {
 
   return ServerConnection.makeRequest(url, request, settings).then(response => {
     if (response.status !== 200) {
-      const error = new ServerConnection.ResponseError(response);
-      showErrorMessage('Fail to extract the archive file', error);
-      throw error;
+      response.json().then(data => {
+        showErrorMessage('Fail to extract the archive file', data.reason);
+        throw new ServerConnection.ResponseError(response);
+      });
     }
   });
 }


### PR DESCRIPTION
Ref #100 

This PR shows an error message dialog when extraction failed like below image.
![ScreenShot 2022-10-18 16 21 21](https://user-images.githubusercontent.com/4404574/196364280-a466130e-f2cf-42b1-a38d-d2b8889774e0.png)

For example, if I implement `raise web.HTTPError(400, "detailed error message")` on the notebook server side,
is there a good way to display this `detailed error message` in the dialog?
Since error response is returned in HTML, I could not find a good way to do it.