### PR TITLE
Set packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "watch:labextension": "jupyter labextension watch .",
         "watch:src": "tsc -w --sourceMap"
     },
+    "packageManager": "yarn@3.5.0",
     "dependencies": {
         "@jupyterlab/application": "^4.0.3",
         "@jupyterlab/apputils": "^4.1.3",


### PR DESCRIPTION
Prevent dependabot of using a wrong yarn version that may result in yarn.lock format changes